### PR TITLE
Cherry-pick clear_struct_list from origin/master

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -799,7 +799,7 @@ int main(int argc, char *argv[])
   else
     bpftrace.out_->attached_probes(num_probes);
 
-  bpftrace.bpforc_ = std::move(bpforc);
+  bpftrace.bpforc_ = bpforc.get();
   err = bpftrace.run();
   if (err)
     return err;

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -146,6 +146,10 @@ public:
   static std::string get_struct_name(const std::string &category,
                                      const std::string &event_name);
   static std::string get_struct_name(const std::string &probe_id);
+  static void clear_struct_list()
+  {
+    struct_list.clear();
+  }
 
 private:
   static std::string parse_field(const std::string &line,


### PR DESCRIPTION
Cherry-pick `clear_struct_list` from the main repo. It is required to be able to deploy tracepoints multiple times in BPFTrace.