### PR TITLE
Collect internal error message from ClangParser::parse()

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -701,7 +701,7 @@ void ClangParser::resolve_incomplete_types_from_btf(
  * their definitions but once he redefines any kernel type, he must provide all
  * necessary definitions.
  */
-bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags, std::vector<std::string>* error_messages)
+bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags, std::vector<std::string> *error_messages)
 {
 #ifdef FUZZ
   StderrSilencer silencer;
@@ -795,14 +795,16 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       LOG(ERROR) << "Include headers with missing type definitions or install "
                     "BTF information to your system.";
     }
-    if (error_messages != nullptr) {
+    if (error_messages != nullptr)
+    {
       *error_messages = handler.get_error_messages();
     }
     return false;
   }
 
   CXCursor cursor = handler.get_translation_unit_cursor();
-  if (error_messages != nullptr) {
+  if (error_messages != nullptr)
+  {
     *error_messages = handler.get_error_messages();
   }
   return visit_children(cursor, bpftrace);

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -701,7 +701,7 @@ void ClangParser::resolve_incomplete_types_from_btf(
  * their definitions but once he redefines any kernel type, he must provide all
  * necessary definitions.
  */
-bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags)
+bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags, std::vector<std::string>* error_messages)
 {
 #ifdef FUZZ
   StderrSilencer silencer;
@@ -795,10 +795,16 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       LOG(ERROR) << "Include headers with missing type definitions or install "
                     "BTF information to your system.";
     }
+    if (error_messages != nullptr) {
+      *error_messages = handler.get_error_messages();
+    }
     return false;
   }
 
   CXCursor cursor = handler.get_translation_unit_cursor();
+  if (error_messages != nullptr) {
+    *error_messages = handler.get_error_messages();
+  }
   return visit_children(cursor, bpftrace);
 }
 

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -19,7 +19,7 @@ public:
   bool parse(ast::Program *program,
              BPFtrace &bpftrace,
              std::vector<std::string> extra_flags = {},
-             std::vector<std::string>* error_messages = nullptr);
+             std::vector<std::string> *error_messages = nullptr);
 
 private:
   bool visit_children(CXCursor &cursor, BPFtrace &bpftrace);

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -18,7 +18,8 @@ class ClangParser
 public:
   bool parse(ast::Program *program,
              BPFtrace &bpftrace,
-             std::vector<std::string> extra_flags = {});
+             std::vector<std::string> extra_flags = {},
+             std::vector<std::string>* error_messages = nullptr);
 
 private:
   bool visit_children(CXCursor &cursor, BPFtrace &bpftrace);


### PR DESCRIPTION
Signed-off-by: yzhao1012 <yzhao@pixielabs.ai>

This adds a result argument, a vector of string, to collect error messages reported during ClangParser::parse().

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
