### PR TITLE
Remove system_include_paths() due to segfault

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -721,14 +721,14 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       .Contents = input.c_str(),
       .Length = input.size(),
   });
-
-  args = { "-isystem", "/bpftrace/include" };
-  auto system_paths = system_include_paths();
-  for (auto &path : system_paths)
-  {
-    args.push_back("-isystem");
-    args.push_back(path.c_str());
-  }
+  
+  // clang-format off
+  args = {
+    "-isystem", "/usr/local/include",
+    "-isystem", "/bpftrace/include",
+    "-isystem", "/usr/include",
+  };
+  // clang-format on
   std::string arch_path = get_arch_include_path();
   args.push_back("-isystem");
   args.push_back(arch_path.c_str());

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -722,6 +722,8 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       .Length = input.size(),
   });
   
+  // args originally were dynamically determined with system_include_paths(), which uses clang. This, however, causes an exception when clang is 
+  // not found inside the container. We have reverted it to use hard-coded include paths.
   // clang-format off
   args = {
     "-isystem", "/usr/local/include",


### PR DESCRIPTION
system_include_paths() uses clang to dynamically find include paths, but causes a segfault when an exception is thrown. Revert to using fixed paths.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
